### PR TITLE
UPDATE Dockerfile to add bochs in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM ubuntu:16.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y gcc-multilib make nasm bear bc mtools git
+    apt-get install -y gcc-multilib make nasm bear bc mtools git libvncserver-dev libgcrypt-dev build-essential curl
+
+RUN cd /tmp &&  curl -L# https://sourceforge.net/projects/bochs/files/bochs/2.8/bochs-2.8.tar.gz | tar xz --strip-components=1
+RUN cd /tmp && ./configure --with-vncsrv --enable-debugger CXXFLAGS="-fpermissive" && make
+RUN mkdir -p /usr/local/share/bochs && cp -r /tmp/bios/* /usr/local/share/bochs && cp /tmp/bochs /usr/bin/bochs
 
 # 为gcc添加编译选项
 RUN echo '#!/bin/bash\n/usr/bin/gcc -fno-stack-protector -m32 "$@"' > /usr/local/bin/gcc && chmod +x /usr/local/bin/gcc
@@ -13,3 +17,7 @@ RUN echo '#!/bin/bash\n/usr/bin/ld -m elf_i386 "$@"' > /usr/local/bin/ld && chmo
 # 添加patch_buildimg.sh
 COPY ./patch_buildimg.sh /usr/local/bin/patch_buildimg.sh
 RUN chmod +x /usr/local/bin/patch_buildimg.sh
+RUN apt-get autoremove -y build-essential curl
+RUN rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
+EXPOSE 5900
+WORKDIR /mnt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM ubuntu:16.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y gcc-multilib make nasm bear bc mtools git libvncserver-dev libgcrypt-dev build-essential curl
+    apt-get install -y gcc-multilib make nasm bear bc mtools git libvncserver-dev libgcrypt-dev build-essential curl libgtk2.0-dev
 
-RUN cd /tmp &&  curl -L# https://sourceforge.net/projects/bochs/files/bochs/2.8/bochs-2.8.tar.gz | tar xz --strip-components=1
-RUN cd /tmp && ./configure --with-vncsrv --enable-debugger CXXFLAGS="-fpermissive" && make
-RUN mkdir -p /usr/local/share/bochs && cp -r /tmp/bios/* /usr/local/share/bochs && cp /tmp/bochs /usr/bin/bochs
+RUN cd /tmp &&  curl -L# https://sourceforge.net/projects/bochs/files/bochs/2.6.11/bochs-2.6.11.tar.gz | tar xz --strip-components=1
+RUN cd /tmp && ./configure --with-vncsrv --enable-debugger CXXFLAGS="-fpermissive" && make && make install
 
 # 为gcc添加编译选项
 RUN echo '#!/bin/bash\n/usr/bin/gcc -fno-stack-protector -m32 "$@"' > /usr/local/bin/gcc && chmod +x /usr/local/bin/gcc
@@ -20,4 +19,3 @@ RUN chmod +x /usr/local/bin/patch_buildimg.sh
 RUN apt-get autoremove -y build-essential curl
 RUN rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*
 EXPOSE 5900
-WORKDIR /mnt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:16.04
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
-    apt-get install -y gcc-multilib make nasm bear bc mtools git libvncserver-dev libgcrypt-dev build-essential curl libgtk2.0-dev
+    apt-get install -y gcc-multilib make nasm bear bc mtools git libvncserver-dev libgcrypt-dev build-essential curl libgtk2.0-dev bochs
 
-RUN cd /tmp &&  curl -L# https://sourceforge.net/projects/bochs/files/bochs/2.6.11/bochs-2.6.11.tar.gz | tar xz --strip-components=1
+RUN cd /tmp &&  curl -L# https://sourceforge.net/projects/bochs/files/bochs/2.8/bochs-2.8.tar.gz | tar xz --strip-components=1
 RUN cd /tmp && ./configure --with-vncsrv --enable-debugger CXXFLAGS="-fpermissive" && make && make install
 
 # 为gcc添加编译选项


### PR DESCRIPTION
## 添加Bochs
build时构建bochs，bochs版本为2.8

bochs vnc图形化显示(vnc端口5900)，启动参数需加入端口映射 

`docker run -it -p 5900:5900 osfs_docker`

## 下面为最小demo

bochsrc
```
floppya: 1_44=hello.bin, status=inserted
boot: a
```

![CleanShot 2025-07-01 at 18 37 14@2x](https://github.com/user-attachments/assets/9a713961-933e-415c-9f98-3b54ffe2eb36)
